### PR TITLE
Avoid scanning test files

### DIFF
--- a/phpdoc/drupal9.xml
+++ b/phpdoc/drupal9.xml
@@ -24,6 +24,7 @@
                 <extension>inc</extension>
                 <extension>install</extension>
                 <extension>theme</extension>
+                <extension>profile</extension>
             </extensions>
             <include-source>true</include-source>
         </api>

--- a/phpdoc/drupal9.xml
+++ b/phpdoc/drupal9.xml
@@ -16,7 +16,7 @@
                 <path>.</path>
             </source>
             <ignore hidden="true" symlinks="true">
-                <path>tests/**/*</path>
+                <path>**/tests/**/*</path>
             </ignore>
             <extensions>
                 <extension>php</extension>


### PR DESCRIPTION
Hi, I find this configuration runs in 4 mins for me[^0] with phpDocumentor 3.5.3 running against Drupal 9.3.x at `c284ccad2ede01ed435f3d5ea4b0e6f4ae2898b9`, which perhaps moves it into the realms of usable. I think the previous config wasn't correctly excluding tests. Obviously everything's also gotten quicker since you made this as well (:

Thanks!

[^0]: PHP 8.2.24, AMD Ryzen 5 7600, nvme ssd, 32 GB RAM (though I ran phpdoc with `memory_limit=8G`)